### PR TITLE
as.tibble() is deprecated in gopher.R, change it to as_tibble()

### DIFF
--- a/src/R/gopher.R
+++ b/src/R/gopher.R
@@ -84,7 +84,7 @@ gopher <- function(genes=character(0),
       message(f)
       return(NULL)
     }
-    return(as.tibble(f) %>% arrange(padj))
+    return(as_tibble(f) %>% arrange(padj))
   }, tasks)
   names(parsed) <- tasks
   return(parsed)


### PR DESCRIPTION
Minor fix, to remove the warning message after running gopher