### PR TITLE
Update synthetic transcripts

### DIFF
--- a/src/R/createSyntheticTranscripts.R
+++ b/src/R/createSyntheticTranscripts.R
@@ -73,7 +73,7 @@
   newgff$source <- "UPSC"
 
   ## sort
-  newgff <- newgff[order(seq_name(newgff), newgff[, 1],
+  newgff <- newgff[order(seqnames(newgff), newgff[, 1],
                          factor(as.character(newgff$type),
                                 labels = seq_len(2 + length(features)),
                                 levels = c("gene", features, "exon"))), ]

--- a/src/R/createSyntheticTranscripts.R
+++ b/src/R/createSyntheticTranscripts.R
@@ -7,7 +7,7 @@
   features <- match.arg(features, several.ok = TRUE)
   output <- match.arg(output)
 
-  gff <- readGff3(gff3)
+  gff <- readZeroLengthFeaturesGff3(gff3)
 
   ## get the gene <-> pacid map
   # This is mRNA IDs and their parents (genes)

--- a/src/R/createSyntheticTranscripts.R
+++ b/src/R/createSyntheticTranscripts.R
@@ -29,9 +29,7 @@
 
   ## create a set of synthetic exons
   rngList <- IRanges::reduce(
-    IRanges::split(rngs,
-                   idMap[match(mRnaID[mRnaID %in% idMap$ID],
-                               idMap$ID),"Parent"]))
+    split(rngs, idMap[match(mRnaID[mRnaID %in% idMap$ID], idMap$ID), "Parent"]))
 
   ## export the gene, exon and features as gff3
   ## create the new gff object
@@ -56,8 +54,8 @@
   rngList <- rngList[match(geneID[geneID %in% idMap$Parent], names(rngList))]
   exonNumber <- elementLengths(rngList)
   exonGff <- gff[rep(which(sel)[geneID %in% idMap$Parent], exonNumber)]
-  exonGff[,1] <- IRanges::unlist(start(rngList))
-  exonGff[,2] <- IRanges::unlist(end(rngList))
+  exonGff[,1] <- unlist(start(rngList))
+  exonGff[,2] <- unlist(end(rngList))
 
   exonID <- sapply(exonNumber, ":", 1)
   sel <- geneGff$strand == "+"

--- a/src/R/createSyntheticTranscripts.R
+++ b/src/R/createSyntheticTranscripts.R
@@ -52,7 +52,7 @@
 
   ## create the exon gff
   rngList <- rngList[match(geneID[geneID %in% idMap$Parent], names(rngList))]
-  exonNumber <- elementLengths(rngList)
+  exonNumber <- elementNROWS(rngList)
   exonGff <- gff[rep(which(sel)[geneID %in% idMap$Parent], exonNumber)]
   exonGff[,1] <- unlist(start(rngList))
   exonGff[,2] <- unlist(end(rngList))


### PR DESCRIPTION
Some functions have been deprecated, and others updated. I tested the patched version on *P. tremula* v1.0, and the resulting synthetic transcripts were identical to the old version:

```sh
> md5sum Potra01_synthetic_transcripts_update.gff Potra01-synthetic-transcripts-wo-intron.gff
ef9068b74fca981355881e922b27da4e  Potra01_synthetic_transcripts_update.gff
ef9068b74fca981355881e922b27da4e  Potra01-synthetic-transcripts-wo-intron.gff
```